### PR TITLE
Hardcode the db port

### DIFF
--- a/configs/config.cloudrun.yaml
+++ b/configs/config.cloudrun.yaml
@@ -12,7 +12,7 @@ db:
       user: ${DB_USER}
       password: ${DB_PASSWORD}
       host: ${DB_HOST}
-      port: ${DB_PORT}
+      port: 3306
       database: ${DB_NAME}
       charset: utf8
       echo: False


### PR DESCRIPTION
This is because otherwise we need to add in string conversion.

We are lazy and not fixing the code yet.